### PR TITLE
Replaces docker image with correct one

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
     server:
-        image: yannickfricke/satisfactory-server
+        image: yfricke/satisfactory-server
         ports:
             - 15777:15777/udp
             - 15000:15000/udp


### PR DESCRIPTION
Using the current docker-compose file, the following error is thrown:

```
Pulling server (yannickfricke/satisfactory-server:latest)...
ERROR: The image for the service you're trying to recreate has been removed. If you continue, volume data could be lost. Consider backing up your data before continuing.

Continue with the new image? [yN] y
Pulling server (yannickfricke/satisfactory-server:latest)...
ERROR: pull access denied for yannickfricke/satisfactory-server, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```